### PR TITLE
add missing dataset dowload to setup that caused train to fail in jupyter notebook

### DIFF
--- a/KAN_GPT.ipynb
+++ b/KAN_GPT.ipynb
@@ -34,6 +34,7 @@
         "!git pull\n",
         "# Download Dataset\n",
         "!./scripts/download_webtext.sh\n",
+        "!./scripts/download_tinyshakespeare.sh\n",
         "# Install dependencies\n",
         "!pip install -r requirements.txt\n",
         "!pip install -e ."


### PR DESCRIPTION


### Summary :memo:
add missing dataset dowload to setup that caused train to fail in jupyter notebook

### Details
_Describe more what you did on changes._

### Bugfixes :bug: (delete if dind't have any)
- #10 


