### PR TITLE
fix: `NotImplementedError` in download_dataset

### DIFF
--- a/kan_gpt/download_dataset.py
+++ b/kan_gpt/download_dataset.py
@@ -44,8 +44,8 @@ def main(args):
         download_webtext()
     elif args.dataset == "tinyshakespeare":
         download_tinyshakespeare()
-
-    raise NotImplementedError
+    else:
+        raise NotImplementedError
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary :memo:

Fixes the issue of `download_dataset` raising `NotImplementedError` even if a correct dataset name is specified.

### Details

1. `pip install kan_gpt`
2. Download a dataset:
    ```console
    $ python3 -m kan_gpt.download_dataset --dataset tinyshakespeare
    ```
3. Old behavior: raises `NotImplementedError` after downloading the dataset
4. New behavior: the script exits without throwing the error

### Checks

- [ ] Closed #798
- [ ] Tested Changes
- [ ] Shakespeare Approval

Thanks for reviewing!